### PR TITLE
Clean up config file, prefix printing

### DIFF
--- a/ts.py
+++ b/ts.py
@@ -84,7 +84,8 @@ def make_threads_stp(args):
 def run(args):
     log_dir = args.log
     out_dir = 'out'
-    _dt = logwt(log_dir, 'main.log', shift_d=True)
+    _outlog, _errlog, outdate, _errdate = logwt(log_dir, 'main.log', shift_d=True)
+    worker_stdout = outdate.fd
 
     print('Assuming input %s is pto project to be stitched' % args.pto)
     project = PTOProject.from_file_name(args.pto)
@@ -100,7 +101,8 @@ def run(args):
               clip_height=args.clip_height,
               log_dir=log_dir,
               is_full=args.full,
-              dry=args.dry)
+              dry=args.dry,
+              worker_stdout=worker_stdout)
     t.set_threads(threads)
     t.set_verbose(args.verbose)
     t.set_st_dir(args.st_dir)

--- a/ts.py
+++ b/ts.py
@@ -15,36 +15,38 @@ from xystitch.tiler import Tiler
 from xystitch.pto.project import PTOProject
 from xystitch.config import config
 from xystitch.single import singlify, HugeImage
-from xystitch.util import logwt, add_bool_arg, size2str, mksize, mem2pix
+from xystitch.util import logwt, add_bool_arg, size2str, mksize, mem2pix, pix2mem
 
 import argparse
 import glob
-import multiprocessing
 import os
-import re
-import sys
 import time
+import math
 
+def make_threads_stp(args):
+    """
+    Ultimately require:
+    -Number of worker threads
+    -Supertile limit in piexels
 
-def run(args):
+    STP constraints:
+    -Stitching a very large supertile can take a long time
+        Time to add images goes up exponentially per image
+        Maximum tile constraint
+    -Supertiles in old enblend took a lot of memory
+        Maximum total memory constraint
+    """
+
+    # Maximum threads to use
+    # If insufficient memory might reduce
     threads = args.threads
     if not threads:
         threads = config.ts_threads()
     if threads < 1:
         raise Exception('Bad threads')
-    print('Using %d threads' % threads)
-
-    log_dir = args.log
-    out_dir = 'out'
-    _dt = logwt(log_dir, 'main.log', shift_d=True)
-
-    fn = args.pto[0]
+    print('Max threads: %u' % threads)
 
     auto_size = not (args.stp or args.stm or args.stw or args.sth)
-
-    print('Assuming input %s is pto project to be stitched' % args.pto)
-    project = PTOProject.from_file_name(args.pto)
-    print('Creating tiler')
     stp = None
     if args.stp:
         stp = mksize(args.stp)
@@ -52,31 +54,60 @@ def run(args):
         stp = mem2pix(mksize(args.stm))
         print('Memory %s => %s pix' % (args.stm, size2str(stp)))
     elif auto_size:
-        stm = config.super_tile_memory()
-        if stm:
-            stp = mem2pix(mksize(stm))
-            # having issues creating very large
-            if stp > 2**32 / 4:
-                # 66 GB max useful as currently written
-                print('WARNING: reducing to maximum tile size')
-                stp = 2**32 / 4
+        stp = config.st_max_pix()
 
-    t = Tiler(project,
-              out_dir,
+    # having issues creating very large
+    if not args.stp and stp > 2**32 / 4:
+        # 66 GB max useful as currently written
+        print('WARNING: reducing to maximum tile size')
+        stp = 2**32 / 4
+
+    # Keep explicit if given
+    if not args.threads:
+        # Estimate how many supertiles we can fit given memory
+        # Try to make the largest supertiles possible
+        # TODO: consider different strategies
+        # This is "best" making large STs but we could also have "fast"
+        max_mem = config.max_mem()
+        stm = pix2mem(stp)
+        max_st_threads = int(max(math.floor(max_mem / stm), 1))
+        print("Strategy best: memory fits %u STs, %u threads available" % (max_st_threads, threads))
+        print("  Max total memory: %sB" % size2str(max_mem))
+        print("  Max ST pixels: %s" % size2str(stp))
+        print("  Estimated max ST memory: %sB" % size2str(stm))
+        if threads > max_st_threads:
+            print("Reducing threads to safely fit in memory")
+        threads = min(max_st_threads, threads)
+
+    return threads, stp
+
+def run(args):
+    log_dir = args.log
+    out_dir = 'out'
+    _dt = logwt(log_dir, 'main.log', shift_d=True)
+
+    print('Assuming input %s is pto project to be stitched' % args.pto)
+    project = PTOProject.from_file_name(args.pto)
+    print('Creating tiler')
+    threads, stp = make_threads_stp(args)
+
+    t = Tiler(pto=project,
+              out_dir=out_dir,
               stw=mksize(args.stw),
               sth=mksize(args.sth),
               stp=stp,
               clip_width=args.clip_width,
               clip_height=args.clip_height,
               log_dir=log_dir,
-              is_full=args.full)
-    t.threads = threads
-    t.verbose = args.verbose
-    t.st_dir = args.st_dir
-    t.out_extension = args.out_ext
-    t.ignore_errors = args.ignore_errors
-    t.ignore_crop = args.ignore_crop
-    t.st_limit = float(args.st_limit)
+              is_full=args.full,
+              dry=args.dry)
+    t.set_threads(threads)
+    t.set_verbose(args.verbose)
+    t.set_st_dir(args.st_dir)
+    t.set_out_extension(args.out_ext)
+    t.set_ignore_errors(args.ignore_errors)
+    t.set_ignore_crop(args.ignore_crop)
+    t.set_st_limit(float(args.st_limit))
 
     # TODO: make this more proper?
     if args.nona_args:
@@ -85,19 +116,19 @@ def run(args):
         t.enblend_args = args.enblend_args.replace('"', '').split(' ')
 
     if args.super_t_xstep:
-        t.super_t_xstep = args.super_t_xstep
+        t.set_super_t_xstep(args.super_t_xstep)
     if args.super_t_ystep:
-        t.super_t_ystep = args.super_t_ystep
+        t.set_super_t_ystep(args.super_t_ystep)
     if args.clip_width:
-        t.clip_width = args.clip_width
+        t.set_clip_width(args.clip_width)
     if args.clip_height:
-        t.clip_height = args.clip_height
+        t.set_clip_height(args.clip_height)
     # if they specified clip but not supertile step recalculate the step so they don't have to do it
     if args.clip_width or args.clip_height and not (args.super_t_xstep
                                                     or args.super_t_ystep):
         t.recalc_step()
 
-    t.enblend_lock = args.enblend_lock
+    t.set_enblend_lock(args.enblend_lock)
 
     if args.single_dir and not os.path.exists(args.single_dir):
         os.mkdir(args.single_dir)
@@ -209,6 +240,12 @@ def main():
         default=False,
         help=
         'use lock file to only enblend (memory intensive part) one at a time')
+    add_bool_arg(
+        parser,
+        '--dry',
+        default=False,
+        help=
+        'Calculate stitch parameters and exit')
     parser.add_argument('--threads', type=int, default=None)
     parser.add_argument('--log', default='pr0nts', help='Output log file name')
     args = parser.parse_args()

--- a/xystitch/blender.py
+++ b/xystitch/blender.py
@@ -98,7 +98,7 @@ class BlenderFailed(CommandFailed):
 
 
 class Enblend:
-    def __init__(self, input_files, output_file, lock=False):
+    def __init__(self, input_files, output_file, lock=False, pprefix=None):
         self.input_files = input_files
         self.output_file = output_file
         self.compression = None
@@ -111,7 +111,7 @@ class Enblend:
             print('%s: %s' % (datetime.datetime.utcnow().isoformat(), s))
 
         self.p = p
-        self.pprefix = lambda: datetime.datetime.utcnow().isoformat() + ': '
+        self.pprefix = pprefix
         self.stdout = sys.stdout
         self.stderr = sys.stderr
 

--- a/xystitch/execute.py
+++ b/xystitch/execute.py
@@ -251,9 +251,12 @@ class Prefixer:
         self.f.flush()
 
 
+def pprefix_now():
+    return datetime.datetime.utcnow().isoformat() + ': '
+
+
 def timestamp(args, stdout=sys.stdout, stderr=sys.stderr):
-    return prefix(args, stdout, stderr,
-                  lambda: datetime.datetime.utcnow().isoformat() + ': ')
+    return prefix(args, stdout, stderr, pprefix_now)
 
 
 def prefix(args, stdout=sys.stdout, stderr=sys.stderr, prefix=lambda: ''):
@@ -264,13 +267,13 @@ def prefix(args, stdout=sys.stdout, stderr=sys.stderr, prefix=lambda: ''):
                             shell=False,
                             encoding="ascii")
     try:
-        # FIXME
-        if 1:
+        if prefix:
             p_stdout = Prefixer(stdout, prefix)
             p_stderr = Prefixer(stderr, prefix)
         else:
             p_stdout = stdout
             p_stderr = stderr
+
         while subp.poll() is None:
             r_rdy, _w_rdy, _x_rdy = select.select([subp.stdout, subp.stderr],
                                                   [], [], 0.1)

--- a/xystitch/geometry.py
+++ b/xystitch/geometry.py
@@ -21,9 +21,9 @@ def ceil_mult(n, mult, align=0):
     '''Return the first number >= n that is a multiple of mult shifted by align'''
     rem = (n - align) % mult
     if rem == 0:
-        return n
+        return int(n)
     else:
-        return n + mult - rem
+        return int(n + mult - rem)
 
 
 class PolygonQuadTreeItem:

--- a/xystitch/pto/util.py
+++ b/xystitch/pto/util.py
@@ -526,7 +526,7 @@ def rm_red_img(pto):
     if len(to_rm) == len(pto.image_lines):
         raise Exception("Removed all images.  remapper will fail")
     pto.del_images(to_rm)
-    print('Remaining')
+    print('Remaining: %u' % len(pto.image_lines))
     for il in pto.image_lines:
         print('  %s w/ [%s, %s, %s, %s]' %
               (il.get_name(), il.left(), il.right(), il.top(), il.bottom()))

--- a/xystitch/remapper.py
+++ b/xystitch/remapper.py
@@ -95,7 +95,7 @@ class Nona:
     TIFF_SINGLE = "TIFF_m"
     TIFF_MULTILAYER = "TIFF_multilayer"
 
-    def __init__(self, pto_project, output_prefix="nonaout", start_hook=None):
+    def __init__(self, pto_project, output_prefix="nonaout", start_hook=None, pprefix=None):
         if output_prefix is None or len(
                 output_prefix
         ) == 0 or output_prefix == '.' or output_prefix == '..':
@@ -123,7 +123,7 @@ class Nona:
             print(('%s: %s' % (datetime.datetime.utcnow().isoformat(), s)))
 
         self.p = p
-        self.pprefix = lambda: datetime.datetime.utcnow().isoformat() + ': '
+        self.pprefix = pprefix
         self.stdout = sys.stdout
         self.stderr = sys.stderr
         self.start_hook = start_hook

--- a/xystitch/tiler.py
+++ b/xystitch/tiler.py
@@ -532,6 +532,48 @@ class Tiler:
                                                    2 * self.clip_height)
         self.verbose and print("Center ST efficiency: %0.1f%%" % (100.0 * cstp / stp))
 
+    def set_threads(self, threads):
+        self.threads = threads
+
+    def set_verbose(self, verbose):
+        self.verbose = verbose
+
+    def set_st_dir(self, st_dir):
+        self.st_dir = st_dir
+
+    def set_out_extension(self, out_extension):
+        self.out_extension = out_extension
+
+    def set_ignore_errors(self, ignore_errors):
+        self.ignore_errors = ignore_errors
+
+    def set_ignore_crop(self, ignore_crop):
+        self.ignore_crop = ignore_crop
+
+    def set_st_limit(self, st_limit):
+        self.st_limit = st_limit
+
+    def set_nona_args(self, nona_args):
+        self.nona_args = nona_args
+
+    def set_enblend_args(self, enblend_args):
+        self.enblend_args = enblend_args
+
+    def set_super_t_xstep(self, super_t_xstep):
+        self.super_t_xstep = super_t_xstep
+
+    def set_super_t_ystep(self, super_t_ystep):
+        self.super_t_ystep = super_t_ystep
+
+    def set_clip_width(self, clip_width):
+        self.clip_width = clip_width
+
+    def set_clip_height(self, clip_height):
+        self.clip_height = clip_height
+
+    def set_enblend_lock(self, enblend_lock):
+        self.enblend_lock = enblend_lock
+
     def calc_stp(self, stp):
         if self.stw or self.sth:
             raise ValueError("Can't manually specify width/height and do auto")

--- a/xystitch/util.py
+++ b/xystitch/util.py
@@ -248,3 +248,6 @@ def mem2pix(mem):
     # ahah: I think it was disk space and I had misinterpreted it as memory
     # since the files got deleted after the run it wasn't obvious
     #return mem * 35 / 1000
+
+def pix2mem(pix):
+    return pix / (51 / 1000)

--- a/xystitch/util.py
+++ b/xystitch/util.py
@@ -97,13 +97,16 @@ def try_shift_dir(d):
 
 # Print timestamps in front of all output messages
 class IOTimestamp(object):
-    def __init__(self, obj=sys, name='stdout'):
+    def __init__(self, obj=sys, name='stdout', pprefix=None):
         self.obj = obj
         self.name = name
 
         self.fd = obj.__dict__[name]
         obj.__dict__[name] = self
         self.nl = True
+        if pprefix is None:
+            pprefix = lambda: "%s: " % datetime.datetime.utcnow().isoformat()
+        self.pprefix = pprefix
 
     def __del__(self):
         if self.obj:
@@ -121,7 +124,7 @@ class IOTimestamp(object):
             if i == len(parts) - 1 and len(part) == 0:
                 break
             if self.nl:
-                self.fd.write('%s: ' % datetime.datetime.utcnow().isoformat())
+                self.fd.write(self.pprefix())
             self.fd.write(part)
             # Newline results in n + 1 list elements
             # The last element has no newline


### PR DESCRIPTION
WARNING: this is a breaking change to config files and needs a follow up PR to fix README. .pr0nrc is not .tsrc and fields have changed. Part of https://github.com/JohnDMcMaster/xystitch/issues/7

Fixes https://github.com/JohnDMcMaster/xystitch/issues/23

Sample output showing it auto sizing thread pool to make sure STs fit in memory

```
2021-04-25T05:11:51.729070: Creating tiler
2021-04-25T05:11:51.729127: Max threads: 16
2021-04-25T05:11:51.729584: Strategy best: memory fits 8 STs, 16 threads available
2021-04-25T05:11:51.729615:   Max total memory: 101.35gB
2021-04-25T05:11:51.729634:   Max ST pixels: 600m
2021-04-25T05:11:51.729666:   Estimated max ST memory: 11.7647gB
2021-04-25T05:11:51.729681: Reducing threads to safely fit in memory
```

Improves https://github.com/JohnDMcMaster/xystitch/issues/24 , but needs a follow up to formally eliminate st_scalar_heuristic from the code

Fixes https://github.com/JohnDMcMaster/xystitch/issues/9

Sample output below. We might want to prefix master with M or something to make it more explicit, but the worst issues are fixed.

```
2021-04-25T20:42:31.842185 W0: Preparing remapper...
2021-04-25T20:42:31.842223 W0: Starting remapper...
2021-04-25T20:42:31.858591: Server thread idle. dry False, all 1, complete 0 / 1
2021-04-25T20:42:31.858623: Status w/ 0 / 1 supertiles complete, 0 / 8010 tiles complete
```
